### PR TITLE
fix dynamodb key engine

### DIFF
--- a/dynamodb/key_engine.go
+++ b/dynamodb/key_engine.go
@@ -577,9 +577,8 @@ func (e *engine) DeleteUnusedKeys(ctx context.Context, namespace string) (err er
 	expr, err := expression.NewBuilder().
 		WithKeyCondition(
 			expression.Key(hashKey).Equal(expression.Value(namespace)).And(
-				expression.Key(lsiKey).Between(
-					expression.Value("disabled@"+strconv.FormatInt(time.Now().Add(-e.GracePeriod).Unix(), 10)),
-					expression.Value("disabled@"+strconv.FormatInt(time.Now().Unix(), 10)),
+				expression.Key(lsiKey).LessThanEqual(
+					expression.Value("disabled@" + strconv.FormatInt(time.Now().Add(-e.GracePeriod).Unix(), 10)),
 				),
 			),
 		).

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 type version string
 
 // VERSION is the current version of the PII Go Module.
-const VERSION version = "v0.2.0"
+const VERSION version = "v0.2.1"
 
 // Semver parses and returns semver struct.
 func (v version) Semver() *semver.Version {


### PR DESCRIPTION
 Delete unused keys query was wrong:
  - The short **grace period** used in tests doesn't help catch it.