### PR TITLE
feat: add support for nested PII struct

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.50.0
+          version: v1.60
           args: --enable misspell

--- a/.github/workflows/module.yml
+++ b/.github/workflows/module.yml
@@ -21,14 +21,14 @@ jobs:
           - 8090:8080
       
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
     
       - name: Install Dependencies
         run: go mod download
@@ -49,7 +49,7 @@ jobs:
           goveralls -coverprofile=coverage.out -repotoken=${{ secrets.COVERALLS_TOKEN }}
 
       - name: Verify Version Changed
-        uses: tj-actions/changed-files@v19
+        uses: tj-actions/changed-files@v41
         if: ${{ (github.event_name == 'push') }}
         id: version-changed
         with:
@@ -57,7 +57,9 @@ jobs:
              version.go
 
       - name: Read Current Version
-        if: ${{ (steps.version-changed.outputs.any_changed == 'true') && (github.event_name == 'push') }}
+        env:
+          VERSION_CHANGED: ${{ steps.version-changed.outputs.any_changed }}
+        if: ${{ ( env.VERSION_CHANGED == 'true') && (github.event_name == 'push') }}
         run: |
           grep 'const VERSION' version.go | sed -e 's/const VERSION version = "\(v[^"]*\)"/PII_VERSION=\1/' >> $GITHUB_ENV
       

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Run Gosec scanner
         uses: securego/gosec@master

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -15,16 +15,16 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
       
-      - uses: aws-actions/setup-sam@v1
+      - uses: aws-actions/setup-sam@v2
         with:
-          version: 1.40.1
+          version: 1.108.0
 
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ln80/pii
 
-go 1.19
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/protector_test.go
+++ b/protector_test.go
@@ -3,6 +3,7 @@ package pii
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -68,6 +69,9 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		Fullname: "Idir Moore",
 		Gender:   "M",
 		Country:  "MA",
+		Address: testutil.Address{
+			Street: "56559 Von Divide",
+		},
 	}
 	opf1 := pf1
 
@@ -90,14 +94,14 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Encrypt(ctx, &ignored); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := ignored, oignored; want != got {
+		if want, got := ignored, oignored; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 
 		if err := p.Encrypt(ctx, &ignored); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := ignored, oignored; want != got {
+		if want, got := ignored, oignored; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 	})
@@ -144,7 +148,6 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		want := ErrInvalidTagConfiguration
 		for _, value := range tcs {
 			err := p.Encrypt(ctx, value)
-			t.Log("err ---->", err)
 			if !errors.Is(err, want) {
 				t.Errorf("expect err be '%v', got '%v'", want, err)
 			}
@@ -160,10 +163,13 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		}
 
 		// assert personal data are mutated (to a cipher text)
-		if want, got := opf1.Fullname, pf1.Fullname; want == got {
+		if want, got := opf1.Fullname, pf1.Fullname; reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v not be equals", want, got)
 		}
-		if want, got := opf2.Fullname, pf2.Fullname; want == got {
+		if want, got := opf1.Address, pf1.Address; reflect.DeepEqual(want, got) {
+			t.Fatalf("expect %v, %v not be equals", want, got)
+		}
+		if want, got := opf2.Fullname, pf2.Fullname; reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v not be equals", want, got)
 		}
 
@@ -171,15 +177,21 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Decrypt(ctx, &pf1, &pf2); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := opf1.Fullname, pf1.Fullname; want != got {
+		if want, got := opf1.Fullname, pf1.Fullname; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
-		if want, got := opf2.Fullname, pf2.Fullname; want != got {
+		if want, got := opf1.Address, pf1.Address; !reflect.DeepEqual(want, got) {
+			t.Fatalf("expect %v, %v be equals", want, got)
+		}
+		if want, got := opf2.Fullname, pf2.Fullname; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 	})
 
 	t.Run("encrypt-decrypt atomicity", func(t *testing.T) {
+
+		t.Skip("skipping this test as atomicity support has been dropped by now.")
+
 		enc := &testutil.UnstableEncrypterMock{
 			PointOfFailure: 2,
 		}
@@ -209,10 +221,10 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		}
 
 		// expect pii structs to be different from originals
-		if want, got := opf1, pf1; want != got {
+		if want, got := opf1, pf1; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
-		if want, got := opf2, pf2; want != got {
+		if want, got := opf2, pf2; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 
@@ -233,10 +245,10 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		}
 
 		// expect none of pii structs to be decrypted back to normal
-		if want, got := opf1, pf1; want == got {
+		if want, got := opf1, pf1; reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v not be equals", want, got)
 		}
-		if want, got := opf2, pf2; want == got {
+		if want, got := opf2, pf2; reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v not be equals", want, got)
 		}
 	})
@@ -261,7 +273,7 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Encrypt(ctx, &pf1); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := encpf1, pf1; want != got {
+		if want, got := encpf1, pf1; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 
@@ -274,7 +286,7 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Decrypt(ctx, &pf1); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := decpf1, pf1; want != got {
+		if want, got := decpf1, pf1; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 	})
@@ -292,7 +304,7 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Encrypt(ctx, &pf); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := opf.Fullname, pf.Fullname; want == got {
+		if want, got := opf.Fullname, pf.Fullname; reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v not be equals", want, got)
 		}
 		if val := pf.Fullname; !isPackedPII(val) {
@@ -308,10 +320,10 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Decrypt(ctx, &pf); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := pf.TEST_PII_Replacement("Fullname"), pf.Fullname; want != got {
+		if want, got := pf.TEST_PII_Replacement("Fullname"), pf.Fullname; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
-		if want, got := pf.TEST_PII_Replacement("Gender"), pf.Gender; want != got {
+		if want, got := pf.TEST_PII_Replacement("Gender"), pf.Gender; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 
@@ -332,10 +344,10 @@ func TestProtector_EncryptDecrypt(t *testing.T) {
 		if err := p.Decrypt(ctx, &pf); err != nil {
 			t.Fatal("expect err be nil, got", err)
 		}
-		if want, got := pf.TEST_PII_Replacement("Fullname"), pf.Fullname; want != got {
+		if want, got := pf.TEST_PII_Replacement("Fullname"), pf.Fullname; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
-		if want, got := pf.TEST_PII_Replacement("Gender"), pf.Gender; want != got {
+		if want, got := pf.TEST_PII_Replacement("Gender"), pf.Gender; !reflect.DeepEqual(want, got) {
 			t.Fatalf("expect %v, %v be equals", want, got)
 		}
 

--- a/struct.go
+++ b/struct.go
@@ -221,11 +221,13 @@ func (s *piiStruct) replace(fn func(rf ReplaceField, fieldIdx int, val string) (
 			switch {
 			case field.isSlice:
 				for i := 0; i < elem.Len(); i++ {
-					(&piiStruct{
+					if err := (&piiStruct{
 						subID: s.subID, // inherit parent subject ID
 						val:   reflect.Indirect(elem.Index(i)),
 						typ:   piit,
-					}).replace(fn)
+					}).replace(fn); err != nil {
+						return err
+					}
 				}
 
 			case field.isMap:
@@ -239,28 +241,34 @@ func (s *piiStruct) replace(fn func(rf ReplaceField, fieldIdx int, val string) (
 						newElem := reflect.New(mapElem.Type()).Elem()
 						newElem.Set(mapElem)
 
-						(&piiStruct{
+						if err := (&piiStruct{
 							subID: s.subID, // inherit parent subject ID
 							val:   newElem,
 							typ:   piit,
-						}).replace(fn)
+						}).replace(fn); err != nil {
+							return err
+						}
 
 						elem.SetMapIndex(k, newElem)
 						continue
 					}
 
-					(&piiStruct{
+					if err := (&piiStruct{
 						subID: s.subID,
 						val:   reflect.Indirect(elem.MapIndex(k)),
 						typ:   piit,
-					}).replace(fn)
+					}).replace(fn); err != nil {
+						return err
+					}
 				}
 			default:
-				(&piiStruct{
+				if err := (&piiStruct{
 					subID: s.subID,
 					val:   elem,
 					typ:   piit,
-				}).replace(fn)
+				}).replace(fn); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/struct.go
+++ b/struct.go
@@ -5,47 +5,262 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 )
 
 var (
-	tagID            = "pii"
-	tagSubjectID     = "subjectID"
-	tagData          = "data"
-	tagOptsSubjectID = []string{"prefix"}
-	tagOptsData      = []string{"replace"}
+	tagID        = "pii"
+	tagSubjectID = "subjectID"
+	tagData      = "data"
+	tagDive      = "dive"
+	// tagOptsSubjectID = []string{"prefix"}
+	// tagOptsData      = []string{"replace"}
 )
 
 // Errors related to struct PII tag configuration
 var (
-	ErrUnsupportedType         = errors.New("unsupported type must be a struct pointer")
-	ErrUnsupportedFieldType    = errors.New("unsupported field type must be exported string")
 	ErrInvalidTagConfiguration = errors.New("invalid tag configuration")
+
+	ErrUnsupportedType         = errors.New("unsupported type must be a struct pointer")
+	ErrUnsupportedFieldType    = errors.New("unsupported field type must be convertible to string")
+	ErrMultipleNestedSubjectID = errors.New("potential multiple nested subject IDs")
+	ErrSubjectIDNotFound       = errors.New("subject ID not found")
 )
 
+var (
+	stringType = reflect.TypeOf("")
+)
+
+var (
+	cache   map[reflect.Type]*piiStructType = make(map[reflect.Type]*piiStructType)
+	cacheMu sync.RWMutex
+)
+
+type piiStructContext struct {
+	seen map[reflect.Type]*piiStructType
+}
+
+type piiField struct {
+	name                    string
+	isSub, isData, isNested bool
+	prefix                  string
+	replacement             string
+	isSlice, isMap          bool
+	nestedStructType        *piiStructType
+	nestedStructTypeRef     reflect.Type
+	rt                      reflect.Type
+}
+
+func (f piiField) getType(cache map[reflect.Type]*piiStructType) *piiStructType {
+	if f.nestedStructTypeRef != nil {
+		return cache[f.nestedStructTypeRef]
+	}
+	return f.nestedStructType
+}
+
+func (f piiField) IsZero() bool {
+	return f == piiField{}
+}
+
+type piiStructType struct {
+	valid     bool
+	subField  piiField
+	dataField []piiField
+	rt        reflect.Type
+}
+
 type piiStruct struct {
-	index        int
-	reflectValue reflect.Value
-	subID        string
-	prefix       string
-	fields       []string
-	replacements []string
+	typ   piiStructType
+	val   reflect.Value
+	subID string
+}
+
+func ptr[T any](t T) *T {
+	return &t
+}
+
+// resolveSubject resolves the PII struct subject ID value by walking through
+// the struct and its nested PII fields.
+//
+// It returns an error if the subject ID is missing or duplicated.
+func resolveSubject(pt piiStructType, pv reflect.Value) (string, error) {
+	s := ""
+	if !pt.subField.IsZero() {
+		s = pt.subField.prefix + reflect.Indirect(pv.FieldByName(pt.subField.name)).String()
+	}
+
+	for _, piiF := range pt.dataField {
+		if !piiF.isNested {
+			continue
+		}
+
+		piiV := pv.FieldByName(piiF.name)
+		if piiV.IsZero() {
+			continue
+		}
+
+		cacheMu.Lock()
+		piit := piiF.getType(cache)
+		cacheMu.Unlock()
+		if piit == nil {
+			// TBD return error instead??
+			panic(fmt.Errorf("failed to resolve PII field type. This should to be possible %v", piiF))
+		}
+
+		piiV = reflect.Indirect(pv.FieldByName(piiF.name))
+		ss := ""
+		switch {
+		case piiF.isSlice:
+			for i := 0; i < piiV.Len(); i++ {
+				ss, _ = resolveSubject(*piit, piiV.Index(i))
+				if ss != "" {
+					break
+				}
+			}
+		case piiF.isMap:
+			for _, k := range piiV.MapKeys() {
+				ss, _ = resolveSubject(*piit, piiV.MapIndex(k))
+				if ss != "" {
+					break
+				}
+			}
+		default:
+			ss, _ = resolveSubject(*piit, piiV)
+		}
+
+		if ss != "" {
+			if s != "" && s != ss {
+				return "", ErrMultipleNestedSubjectID
+			}
+			s = ss
+		}
+	}
+
+	if s == "" {
+		return "", ErrSubjectIDNotFound
+	}
+	return s, nil
+}
+
+func (ps *piiStruct) resolveSubject() (string, error) {
+	if ps.subID == "" {
+		var err error
+		ps.subID, err = resolveSubject(ps.typ, ps.val)
+		if err != nil {
+			return "", err
+		}
+	}
+	return ps.subID, nil
 }
 
 func (ps *piiStruct) subjectID() string {
-	return ps.prefix + ps.subID
+	s, err := ps.resolveSubject()
+	if err != nil {
+		panic(err)
+	}
+	return s
 }
 
-func (s *piiStruct) replace(fn func(fieldIdx int, val string) (string, error)) error {
-	for idx, field := range s.fields {
-		el := reflect.Indirect(s.reflectValue.FieldByName(field))
-		switch el.Kind() {
-		case reflect.String:
-			if el.CanSet() {
-				newVal, err := fn(idx, el.String())
-				if err != nil {
-					return err
+type ReplaceField struct {
+	SubjectID   string
+	Name        string
+	RType       reflect.Type
+	Replacement string
+}
+
+func (s *piiStruct) replace(fn func(rf ReplaceField, fieldIdx int, val string) (string, error)) error {
+	var (
+		newVal string
+		err    error
+	)
+	for idx, field := range s.typ.dataField {
+		v := s.val.FieldByName(field.name)
+
+		if v.IsZero() {
+			continue
+		}
+
+		if !v.CanSet() {
+			continue
+		}
+		elem := reflect.Indirect(v)
+
+		if field.isData {
+			val := elem.String()
+
+			newVal, err = fn(ReplaceField{
+				SubjectID:   s.subID,
+				RType:       field.rt,
+				Name:        field.name,
+				Replacement: field.replacement,
+			}, idx, val)
+			if err != nil {
+				return err
+			}
+			if newVal != val {
+				elem.SetString(newVal)
+			}
+			continue
+		}
+
+		if field.isNested {
+			var piit piiStructType
+
+			cacheMu.Lock()
+			piiT := field.getType(cache)
+			cacheMu.Unlock()
+
+			if piiT == nil {
+				panic(fmt.Errorf("failed to resolve PII field type. This should to be possible %v", field))
+			}
+			piit = *piiT
+			if !piiT.valid {
+				continue
+			}
+
+			switch {
+			case field.isSlice:
+				for i := 0; i < elem.Len(); i++ {
+					(&piiStruct{
+						subID: s.subID, // inherit parent subject ID
+						val:   reflect.Indirect(elem.Index(i)),
+						typ:   piit,
+					}).replace(fn)
 				}
-				el.SetString(newVal)
+
+			case field.isMap:
+				for _, k := range elem.MapKeys() {
+					mapElem := elem.MapIndex(k)
+					if mapElem.IsZero() {
+						continue
+					}
+					mapElem = reflect.Indirect(elem.MapIndex(k))
+					if !mapElem.CanAddr() {
+						newElem := reflect.New(mapElem.Type()).Elem()
+						newElem.Set(mapElem)
+
+						(&piiStruct{
+							subID: s.subID, // inherit parent subject ID
+							val:   newElem,
+							typ:   piit,
+						}).replace(fn)
+
+						elem.SetMapIndex(k, newElem)
+						continue
+					}
+
+					(&piiStruct{
+						subID: s.subID,
+						val:   reflect.Indirect(elem.MapIndex(k)),
+						typ:   piit,
+					}).replace(fn)
+				}
+			default:
+				(&piiStruct{
+					subID: s.subID,
+					val:   elem,
+					typ:   piit,
+				}).replace(fn)
 			}
 		}
 	}
@@ -70,54 +285,149 @@ func (m piiMap) subjectIDs() []string {
 	return subIDs
 }
 
-func indexOfTagOpt(optName string, opts []string) int {
-	for k, v := range opts {
-		if optName == v {
-			return k
-		}
-	}
-	return -1
-}
-
-func parseTag(tagStr, name string, opts []string) (ok bool, optVals []string) {
+func parseTag(tagStr string) (name string, optVals map[string]string) {
 	if tagStr == "" {
 		return
 	}
 
 	tags := strings.Split(tagStr, ",")
-	ok = strings.TrimSpace(tags[0]) == name
-	optCount := len(opts)
 
-	if !ok || optCount == 0 {
-		return
-	}
+	name = strings.TrimSpace(tags[0])
 
-	optVals = make([]string, optCount)
+	optVals = make(map[string]string)
 	for _, opt := range tags[1:] {
 		splits := strings.Split(opt, "=")
 		if len(splits) == 2 {
 			name, val := strings.TrimSpace(splits[0]), strings.TrimSpace(splits[1])
-			if idx := indexOfTagOpt(name, opts); idx != -1 {
-				optVals[idx] = val
-			}
+			optVals[name] = val
 		}
 	}
 
 	return
 }
 
-func scan(values ...interface{}) (indexes piiMap, err error) {
-	indexes = make(map[int]*piiStruct)
+func scanStruct(rt reflect.Type) (piiStructType, error) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	if _, ok := cache[rt]; !ok {
+		c := piiStructContext{seen: cache}
+		piit, err := scanStructWithContext(c, rt)
+		if err != nil {
+			return piiStructType{}, err
+		}
+		cache[rt] = &piit
+	}
+
+	return *cache[rt], nil
+}
+
+func scanStructWithContext(c piiStructContext, rt reflect.Type) (piiStructType, error) {
+	piiFields := make([]piiField, 0)
+	var subjectField piiField
+	for i := 0; i < rt.NumField(); i++ {
+		v := rt.Field(i)
+		tags := v.Tag.Get(tagID)
+		if tags == "" {
+			continue
+		}
+
+		vv, _ := rt.FieldByName(v.Name)
+		if !vv.IsExported() {
+			continue
+		}
+
+		name, opts := parseTag(tags)
+		piiF := piiField{
+			name:        v.Name,
+			isSub:       name == tagSubjectID,
+			isData:      name == tagData,
+			isNested:    name == tagDive,
+			prefix:      opts["prefix"],
+			replacement: opts["replace"],
+			rt:          v.Type,
+		}
+
+		switch {
+		case piiF.isSub:
+			// if v.Type.Kind() != reflect.String {
+			// 	continue
+			// }
+			if !v.Type.ConvertibleTo(stringType) {
+				return piiStructType{}, ErrUnsupportedFieldType
+			}
+
+			if !subjectField.IsZero() {
+				return piiStructType{}, ErrMultipleNestedSubjectID
+			}
+			subjectField = piiF
+
+		case piiF.isData:
+			tt := v.Type
+			if tt.Kind() == reflect.Ptr {
+				tt = tt.Elem()
+			}
+			if tt.Kind() != reflect.String {
+				continue
+			}
+			piiFields = append(piiFields, piiF)
+
+		case piiF.isNested:
+			tt := vv.Type
+			if tt.Kind() == reflect.Ptr {
+				tt = tt.Elem()
+			}
+			if tt.Kind() == reflect.Slice {
+				piiF.isSlice = true
+				tt = tt.Elem()
+			}
+			if tt.Kind() == reflect.Map {
+				piiF.isMap = true
+				tt = tt.Elem()
+			}
+			if tt.Kind() == reflect.Ptr {
+				tt = tt.Elem()
+			}
+
+			_, seen := c.seen[tt]
+			if !seen {
+				var ppiit piiStructType
+				var err error
+				c.seen[tt] = &ppiit
+				ppiit, err = scanStructWithContext(c, tt)
+				if err != nil {
+					return piiStructType{}, err
+				}
+				piiF.nestedStructType = &ppiit
+			} else {
+				piiF.nestedStructTypeRef = tt
+			}
+
+			piiFields = append(piiFields, piiF)
+		}
+	}
+
+	return piiStructType{
+		valid:     len(piiFields) > 0,
+		subField:  subjectField,
+		dataField: piiFields,
+		rt:        rt,
+	}, nil
+}
+
+func scan(values ...any) (indexes piiMap, err error) {
+	indexes = make(map[int]*piiStruct, len(values))
 
 	defer func() {
-		if err != nil && !errors.Is(err, ErrUnsupportedType) && !errors.Is(err, ErrUnsupportedFieldType) {
-			err = fmt.Errorf("%w: %v", ErrInvalidTagConfiguration, err)
+		if err != nil {
+			err = errors.Join(ErrInvalidTagConfiguration, err)
 		}
 	}()
 
 	for idx, v := range values {
 		v := v
 		val := reflect.ValueOf(v)
+
 		if val.Kind() != reflect.Ptr {
 			return nil, fmt.Errorf("%w at #%d", ErrUnsupportedType, idx)
 		}
@@ -127,69 +437,25 @@ func scan(values ...interface{}) (indexes piiMap, err error) {
 		}
 
 		elem := val.Elem()
-		for i := 0; i < ift.NumField(); i++ {
-			v := ift.Field(i)
-			el := reflect.Indirect(elem.FieldByName(v.Name))
-			switch el.Kind() {
-			case reflect.String:
-				if el.CanSet() {
-					tags := v.Tag.Get(tagID)
-					input := el.String()
 
-					if ok, opts := parseTag(tags, tagSubjectID, tagOptsSubjectID); ok {
-						if vidx, ok := indexes[idx]; ok {
-							if vidx.subID != "" {
-								return nil, fmt.Errorf("subjectID defined multiple time at #%d", idx)
-							} else {
-								vidx.subID = input
-							}
-						} else {
-							indexes[idx] = &piiStruct{
-								index:  idx,
-								subID:  input,
-								prefix: opts[0],
-								fields: []string{},
-							}
-						}
-					} else if ok, opts = parseTag(tags, tagData, tagOptsData); ok {
-						if _, ok := indexes[idx]; !ok {
-							indexes[idx] = &piiStruct{
-								index:  idx,
-								fields: []string{},
-							}
-						}
-						indexes[idx].fields = append(indexes[idx].fields, v.Name)
-						indexes[idx].replacements = append(indexes[idx].replacements, opts[0])
-					}
-				}
-
-			default:
-				if el.CanSet() {
-					tags := v.Tag.Get(tagID)
-					if ok, _ := parseTag(tags, tagSubjectID, tagOptsSubjectID); ok {
-						return nil, fmt.Errorf("%w field '%s.%s' at #%d", ErrUnsupportedFieldType, ift.String(), v.Name, idx)
-					}
-				}
-			}
+		piiType, err := scanStruct(ift)
+		if err != nil {
+			return nil, err
 		}
-
-		// case of current values does not have pii tag configured
-		if _, ok := indexes[idx]; !ok {
+		if !piiType.valid {
 			continue
 		}
 
-		// return an error if a struct does not have subject id
-		if indexes[idx].subID == "" {
-			return nil, fmt.Errorf("subjectID not found at #%d", idx)
+		piiStruct := &piiStruct{
+			typ: piiType,
+			val: elem,
 		}
 
-		// ignore struct if it does not have personal fields
-		if len(indexes[idx].fields) == 0 {
-			delete(indexes, idx)
-			continue
+		if _, err := piiStruct.resolveSubject(); err != nil {
+			return nil, err
 		}
 
-		indexes[idx].reflectValue = elem
+		indexes[idx] = piiStruct
 	}
 
 	return indexes, nil

--- a/struct_test.go
+++ b/struct_test.go
@@ -1,0 +1,416 @@
+package pii
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestStruct(t *testing.T) {
+	// replaceFn does empty PII fields. This particular behavior makes testing easier.
+	replaceFn := func(rf ReplaceField, fieldIdx int, val string) (newVal string, err error) {
+		return "", nil
+	}
+
+	// Helper structs:
+
+	type Email string
+
+	type Profile struct {
+		ID    string  `pii:"subjectID"`
+		Email Email   `pii:"data"`
+		Phone *string `pii:"data"`
+	}
+
+	type Address struct {
+		Street string `pii:"data"`
+	}
+
+	type tc struct {
+		val  any
+		want any
+		ok   bool
+		err  error
+	}
+	tcs := []tc{
+		{
+			val: &Profile{
+				ID:    "abc",
+				Email: "email@example.com",
+			},
+			want: &Profile{
+				ID: "abc",
+			},
+			ok: true,
+		},
+		{
+			val: &Profile{
+				ID:    "abc",
+				Email: "email@example.com",
+				Phone: ptr("519-491-6780"),
+			},
+			want: &Profile{
+				ID:    "abc",
+				Phone: ptr(""),
+			},
+			ok: true,
+		},
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address *Address `pii:"dive"`
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: nil,
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: nil,
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address *Address `pii:"dive"`
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: &Address{
+						Street: "7234 Antone Springs",
+					},
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: &Address{
+						Street: "",
+					},
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address []Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: []Address{
+						{
+							Street: "7234 Antone Springs",
+						},
+						{
+							Street: "90 Kerluke Pine DS",
+						},
+					},
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: []Address{
+						{},
+						{},
+					},
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address []Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address []*Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: []*Address{
+						{
+							Street: "7234 Antone Springs",
+						},
+					},
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: []*Address{
+						{},
+					},
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address map[string]*Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: map[string]*Address{
+						"A": {
+							Street: "7234 Antone Springs",
+						},
+					},
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: map[string]*Address{
+						"A": {
+							Street: "",
+						},
+					},
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address map[string]*Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: nil,
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: nil,
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Address map[string]Address `pii:"dive"`
+				Company string
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: map[string]Address{
+						"A": {
+							Street: "7234 Antone Springs",
+						},
+					},
+					Company: "company name",
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: map[string]Address{
+						"A": {
+							Street: "",
+						},
+					},
+					Company: "company name",
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Child   *T `pii:"dive"`
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Child: &T{
+						Profile: Profile{
+							ID:    "abc",
+							Email: "email.child@example.com",
+						},
+					},
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Child: &T{
+						Profile: Profile{
+							ID: "abc",
+						},
+					},
+				},
+				ok: true,
+			}
+		}(),
+		func() tc {
+			type T struct {
+				Profile `pii:"dive"`
+				Child   *T `pii:"dive"`
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Child: &T{
+						Profile: Profile{
+							ID:    "abc_child",
+							Email: "email.child@example.com",
+						},
+					},
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+
+					Child: &T{
+						Profile: Profile{
+							ID: "abc_child",
+						},
+					},
+				},
+				ok:  false,
+				err: ErrMultipleNestedSubjectID,
+				// err: ErrInvalidTagConfiguration,
+			}
+		}(),
+		func() tc {
+			type NestedAddress struct {
+				Address `pii:"dive"`
+				Sub     *Address `pii:"dive"`
+			}
+			type T struct {
+				Profile `pii:"dive"`
+				Address NestedAddress `pii:"dive"`
+			}
+			return tc{
+				val: &T{
+					Profile: Profile{
+						ID:    "abc",
+						Email: "email@example.com",
+					},
+					Address: NestedAddress{
+						Address: Address{
+							Street: "7234 Antone Springs",
+						},
+						Sub: &Address{
+							Street: "26559 Senger Crossing",
+						},
+					},
+				},
+				want: &T{
+					Profile: Profile{
+						ID: "abc",
+					},
+					Address: NestedAddress{
+						Address: Address{
+							Street: "",
+						},
+						Sub: &Address{
+							Street: "",
+						},
+					},
+				},
+				ok: true,
+			}
+		}(),
+	}
+
+	for i, tc := range tcs {
+		t.Run("tc: "+strconv.Itoa(i+1), func(t *testing.T) {
+			sm, err := scan(tc.val)
+			if !tc.ok {
+				if !errors.Is(err, tc.err) {
+					t.Fatalf("expect err is %v, got %v", tc.err, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatal("expect err be nil, got", err)
+			}
+			s := sm[0]
+
+			_ = s.replace(replaceFn)
+
+			if !reflect.DeepEqual(tc.want, tc.val) {
+				t.Fatalf("expect %s, %s be equals", tc.want, tc.val)
+			}
+		})
+	}
+}

--- a/testutil/struct.go
+++ b/testutil/struct.go
@@ -1,9 +1,14 @@
 package testutil
 
+type Address struct {
+	Street string `pii:"data"`
+}
+
 type Profile struct {
-	UserID   string `pii:"subjectID"`
-	Fullname string `pii:"data,replace=deleted pii"`
-	Gender   string `pii:"data"`
+	UserID   string  `pii:"subjectID"`
+	Fullname string  `pii:"data,replace=deleted pii"`
+	Gender   string  `pii:"data"`
+	Address  Address `pii:"dive"`
 	Country  string
 }
 


### PR DESCRIPTION

In this PR:

- Add support for nested PII structs; this requires adding the tag ```pii:"dive"``` to the nested field.
- Nested PII field can be a struct, struct pointer, slice, or map.
- Support for batch atomicity was dropped (by now) as it added extra complexity.