### PR TITLE
Feat: support PII masking

### DIFF
--- a/mask.go
+++ b/mask.go
@@ -1,0 +1,89 @@
+package pii
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"unicode"
+)
+
+// Mask does partially redact PII data using a set of pre defined masks
+// for different PII kinds such as `email`, `ipv4_addr`, `credit_card`.
+func Mask(structPtr any) error {
+	option := func(rc *RedactConfig) {
+		rc.RedactFunc = func(fr FieldReplace, val string) (string, error) {
+			switch fr.Kind {
+			case "email":
+				return MaskEmail(val)
+			case "credit_card":
+				return MaskCreditCard(val)
+			case "ipv4_addr":
+				return MaskIPv4Addr(val, 1)
+			default:
+				return defaultRedactFunc(fr, val)
+			}
+		}
+	}
+	return Redact(structPtr, option)
+}
+
+// MaskEmail redacts the local part of an email address
+func MaskEmail(email string) (string, error) {
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return "", errors.New("invalid email format")
+	}
+
+	maskedLocal := strings.Repeat("*", len(parts[0]))
+
+	return maskedLocal + "@" + parts[1], nil
+}
+
+// MaskCreditCard redacts all digits except the last four in a credit card number
+func MaskCreditCard(cardNumber string) (string, error) {
+	var digits []rune
+	for _, char := range cardNumber {
+		if unicode.IsDigit(char) {
+			digits = append(digits, char)
+		}
+	}
+	if len(digits) < 4 {
+		return "", errors.New("invalid credit card length")
+	}
+
+	redacted := strings.Repeat("*", len(digits)-4) + string(digits[len(digits)-4:])
+
+	var result strings.Builder
+	nonDigitIndex := 0
+	for _, char := range cardNumber {
+		if unicode.IsDigit(char) {
+			if nonDigitIndex < len(redacted) {
+				result.WriteRune(rune(redacted[nonDigitIndex]))
+				nonDigitIndex++
+			}
+		} else {
+			result.WriteRune(char)
+		}
+	}
+	return result.String(), nil
+}
+
+// maskIPv4 masks the last `n` octets of an IPv4 address with "***".
+func MaskIPv4Addr(ip string, octetsToMask int) (string, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil || strings.Contains(ip, ":") {
+		return "", fmt.Errorf("invalid IPv4 address")
+	}
+
+	octets := strings.Split(ip, ".")
+	if len(octets) != 4 {
+		return "", fmt.Errorf("invalid IPv4 address format")
+	}
+
+	for i := 4 - octetsToMask; i < 4; i++ {
+		octets[i] = "***"
+	}
+
+	return strings.Join(octets, "."), nil
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -1,0 +1,77 @@
+package pii
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestMask(t *testing.T) {
+	type Device struct {
+		IPAddr string `pii:"data,kind=ipv4_addr"`
+	}
+
+	type CreditCard struct {
+		Number string `pii:"data,kind=credit_card"`
+	}
+
+	type Profile struct {
+		Email       string       `pii:"data,kind=email"`
+		Fullname    string       `pii:"data"`
+		Device      Device       `pii:"dive"`
+		CreditCards []CreditCard `pii:"dive"`
+	}
+
+	tcs := []struct {
+		val  any
+		want any
+		ok   bool
+		err  error
+	}{
+		{
+			val:  nil,
+			want: nil,
+			ok:   false,
+			err:  ErrUnsupportedType,
+		},
+		{
+			val: &Profile{
+				Email:    "email@example.com",
+				Fullname: "Guadalupe Kemmer DDS",
+				Device: Device{
+					IPAddr: "169.251.207.194",
+				},
+				CreditCards: []CreditCard{{Number: "6706 7510 5149 0155"}},
+			},
+			want: &Profile{
+				Email:    "*****@example.com",
+				Fullname: "********************",
+				Device: Device{
+					IPAddr: "169.251.207.***",
+				},
+				CreditCards: []CreditCard{{Number: "**** **** **** 0155"}},
+			},
+			ok: true,
+		},
+	}
+
+	for i, tc := range tcs {
+		t.Run("tc: "+strconv.Itoa(i), func(t *testing.T) {
+			err := Mask(tc.val)
+			if !tc.ok {
+				if !errors.Is(err, tc.err) {
+					t.Fatalf("expect err is %v, got %v", tc.err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal("expect err be nil, got", err)
+			}
+			if !reflect.DeepEqual(tc.want, tc.val) {
+				t.Fatalf("expect %s, %s be equals", tc.want, tc.val)
+			}
+		})
+	}
+
+}

--- a/mask_test.go
+++ b/mask_test.go
@@ -37,6 +37,18 @@ func TestMask(t *testing.T) {
 		},
 		{
 			val: &Profile{
+				Email:    "invalid_email.com",
+				Fullname: "Guadalupe Kemmer DDS",
+				Device: Device{
+					IPAddr: "169.251.207.194",
+				},
+				CreditCards: []CreditCard{{Number: "invalid_number"}},
+			},
+			// Mask fails if the predefined mask is incompatible with the PII value
+			ok: false,
+		},
+		{
+			val: &Profile{
 				Email:    "email@example.com",
 				Fullname: "Guadalupe Kemmer DDS",
 				Device: Device{
@@ -60,7 +72,10 @@ func TestMask(t *testing.T) {
 		t.Run("tc: "+strconv.Itoa(i), func(t *testing.T) {
 			err := Mask(tc.val)
 			if !tc.ok {
-				if !errors.Is(err, tc.err) {
+				if err == nil {
+					t.Fatal("expect err not to be nil")
+				}
+				if tc.err != nil && !errors.Is(err, tc.err) {
 					t.Fatalf("expect err is %v, got %v", tc.err, err)
 				}
 				return

--- a/struct_test.go
+++ b/struct_test.go
@@ -46,19 +46,19 @@ func TestStruct_Redact(t *testing.T) {
 		},
 		{
 			val:  &Address{Street: "07024 Quigley Trace"},
-			want: &Address{Street: "0****************ce"},
+			want: &Address{Street: "*******************"},
 			ok:   true,
 		},
 		{
 			val:  &Address{Street: "070 a"},
-			want: &Address{Street: "****a"},
+			want: &Address{Street: "*****"},
 			ok:   true,
 		},
 		func() tc {
 			testErr := errors.New("test replace error")
 			return tc{
 				val: &Address{Street: "070 a"},
-				fn: func(rf ReplaceField, val string) (string, error) {
+				fn: func(fr FieldReplace, val string) (string, error) {
 					return "", testErr
 				},
 				ok:  false,
@@ -68,7 +68,7 @@ func TestStruct_Redact(t *testing.T) {
 		{
 			val:  &Address{Street: "070 a"},
 			want: &Address{Street: "*"},
-			fn: func(rf ReplaceField, val string) (string, error) {
+			fn: func(fr FieldReplace, val string) (string, error) {
 				return "*", nil
 			},
 			ok: true,
@@ -81,8 +81,8 @@ func TestStruct_Redact(t *testing.T) {
 			},
 			want: &Profile{
 				ID:    "",
-				Email: "V**********************om",
-				Phone: ptr("2*********29"),
+				Email: "*************************",
+				Phone: ptr("************"),
 			},
 			ok: true,
 		},
@@ -102,9 +102,9 @@ func TestStruct_Redact(t *testing.T) {
 				want: &T{
 					Profile: Profile{
 						ID:    "abc",
-						Email: "e**************om",
+						Email: "*****************",
 					},
-					Address: &Address{Street: "0****************ce"},
+					Address: &Address{Street: "*******************"},
 				},
 				ok: true,
 			}
@@ -135,14 +135,14 @@ func TestStruct_Redact(t *testing.T) {
 				},
 				want: &T{
 					Email:    "****@****.com",
-					Fullname: "S***********te",
+					Fullname: "**************",
 				},
-				fn: func(rf ReplaceField, val string) (string, error) {
+				fn: func(fr FieldReplace, val string) (string, error) {
 					switch {
-					case rf.RType == reflect.TypeOf(Email("")):
+					case fr.RType == reflect.TypeOf(Email("")):
 						return "****@****.com", nil
 					default:
-						return defaultRedactFunc(rf, val)
+						return defaultRedactFunc(fr, val)
 					}
 				},
 				ok: true,
@@ -173,7 +173,7 @@ func TestStruct_Redact(t *testing.T) {
 	}
 }
 
-func TestStruct_Check(t *testing.T) {
+func TestStruct_Found(t *testing.T) {
 	type tc struct {
 		val any
 		ok  bool
@@ -205,7 +205,7 @@ func TestStruct_Check(t *testing.T) {
 	for i, tc := range tcs {
 		t.Run("tc: "+strconv.Itoa(i+1), func(t *testing.T) {
 
-			ok, err := Check(tc.val)
+			ok, err := Found(tc.val)
 
 			if got, want := err, tc.err; !errors.Is(got, want) {
 				t.Fatalf("expect %v, %v be equals", got, want)
@@ -220,11 +220,9 @@ func TestStruct_Check(t *testing.T) {
 
 func TestStruct_Scan(t *testing.T) {
 	// replaceFn does empty PII fields. This particular behavior makes testing easier.
-	replaceFn := func(rf ReplaceField, val string) (newVal string, err error) {
+	replaceFn := func(fr FieldReplace, val string) (newVal string, err error) {
 		return "", nil
 	}
-
-	// Helper structs:
 
 	type tc struct {
 		val  any
@@ -628,7 +626,7 @@ func TestStruct_Scan(t *testing.T) {
 // 	}
 // 	t.Logf("--> %+v", pfs)
 
-// 	err = ps.replace(func(rf ReplaceField, val string) (string, error) {
+// 	err = ps.replace(func(fr FieldReplace, val string) (string, error) {
 
 // 		return "hello", nil
 // 	})

--- a/struct_test.go
+++ b/struct_test.go
@@ -606,34 +606,3 @@ func TestStruct_Scan(t *testing.T) {
 		})
 	}
 }
-
-// func TestStruct_Debug(t *testing.T) {
-
-// 	pf1 := Profile{
-// 		ID:    "abc 1",
-// 		Email: "email@example.com",
-// 	}
-// 	pf2 := Profile{
-// 		ID:    "abc 2",
-// 		Email: "email@example.com",
-// 	}
-
-// 	pfs := []any{pf1, pf2}
-
-// 	ps, err := scan(pfs, false)
-// 	if err != nil {
-// 		t.Fatal("expect err be nil, got", err)
-// 	}
-// 	t.Logf("--> %+v", pfs)
-
-// 	err = ps.replace(func(fr FieldReplace, val string) (string, error) {
-
-// 		return "hello", nil
-// 	})
-
-// 	if err != nil {
-// 		t.Fatal("expect err be nil, got", err)
-// 	}
-
-// 	t.Logf("--> %+v", pfs)
-// }

--- a/wire_format_test.go
+++ b/wire_format_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestWireFormat(t *testing.T) {
-
 	base64 := func(str string) string {
 		return base64.StdEncoding.EncodeToString([]byte(str))
 	}


### PR DESCRIPTION
- Add support for PII masking (aka partial redact).
- Change `pii.Redact` default behavior.
- Add option `kind` to `pii` tag i.e `pii:"data,kind=email"` where **"email"**, **"ipv4_addr"**, **"credit_card"** are predefined.

